### PR TITLE
Partial fix for the notebook to validate the filled spec

### DIFF
--- a/spec_creation/Validate_spec_before_upload.ipynb
+++ b/spec_creation/Validate_spec_before_upload.ipynb
@@ -65,7 +65,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def get_marker(loc, disp_color):\n",
+    "def get_one_marker(loc, disp_color):\n",
     "    if loc[\"geometry\"][\"type\"] == \"Point\":\n",
     "        curr_latlng = lonlat_swap(loc[\"geometry\"][\"coordinates\"])\n",
     "        return folium.Marker(curr_latlng, icon=folium.Icon(color=disp_color),\n",
@@ -77,6 +77,20 @@
     "        # print(\"Returning polygon for %s\" % curr_latlng)\n",
     "        return folium.PolyLine(curr_latlng, color=disp_color, fill=disp_color,\n",
     "                  popup=\"%s\" % loc[\"properties\"][\"name\"])        "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_marker(loc, disp_color):\n",
+    "    if type(loc) == list:\n",
+    "        return [get_one_marker(l, disp_color) for l in loc]\n",
+    "    else:\n",
+    "        print(\"Found single entry, is this expected?\")\n",
+    "        return [get_one_marker(loc, disp_color)]"
    ]
   },
   {
@@ -92,7 +106,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "spec_to_validate = json.load(open(\"final_sfbayarea_filled/train_bus_ebike_mtv_ucb.filled.json\"))\n",
+    "spec_to_validate = json.load(open(\"final_sfbayarea_filled_reroutes/train_bus_ebike_mtv_ucb.filled.reroute.json\"))\n",
     "sensing_configs = json.load(open(\"sensing_regimes.all.specs.json\"))"
    ]
   },
@@ -180,15 +194,15 @@
    "source": [
     "def get_map_for_travel_leg(trip):\n",
     "    curr_map = folium.Map()\n",
-    "    get_marker(trip[\"start_loc\"], \"green\").add_to(curr_map)\n",
-    "    get_marker(trip[\"end_loc\"], \"red\").add_to(curr_map)\n",
+    "    [m.add_to(curr_map) for m in get_marker(trip[\"start_loc\"], \"green\")]\n",
+    "    [m.add_to(curr_map) for m in get_marker(trip[\"end_loc\"], \"red\")]\n",
     "    # trips from relations won't have waypoints\n",
     "    if \"waypoint_coords\" in trip:\n",
     "        for i, wpc in enumerate(trip[\"waypoint_coords\"][\"geometry\"][\"coordinates\"]):\n",
     "            folium.map.Marker(\n",
     "                lonlat_swap(wpc), popup=\"%d\" % i,\n",
     "                icon=fof.DivIcon(class_name='leaflet-div-icon')).add_to(curr_map)\n",
-    "    print(\"Found %d coordinates for the route\" % (len(trip[\"route_coords\"][\"geometry\"][\"coordinates\"])))\n",
+    "    print(\"Found %s coordinates for the route\" % ([len(clist) for clist in trip[\"route_coords\"][\"geometry\"][\"coordinates\"]]))\n",
     "    latlng_route_coords = [lonlat_swap(rc) for rc in trip[\"route_coords\"][\"geometry\"][\"coordinates\"]]\n",
     "    folium.PolyLine(latlng_route_coords,\n",
     "                    popup=\"%s: %s\" % (trip[\"mode\"], trip[\"name\"])).add_to(curr_map)\n",


### PR DESCRIPTION
This is partial fix to the notebook that allows us to visualize the filled spec
before we upload it.

The original version of the notebook still works with the original version of the filled spec
"final_sfbayarea_filled_reroutes/train_bus_ebike_mtv_ucb.filled.reroute.json"

I encourage you to run the original version of the notebook first, and
understand what it does. You might also want to save a local, unmodified copy
that you can refer to while fixing the notebook.

This PR attempts to change the notebook to visualize the new spec format.

Concretely, it renames the existing `get_marker` to `get_one_marker`
and adds a new `get_marker` function to call `get_one_marker` with each
location in the list.

It then modifies `get_map_for_travel_leg` to add all the markers to the map.
This means that we will have the time-dependent variations of the leg displayed
on the same map.

I then discovered a regression in the new `route_coords`.

The original version had the `route_coords` as a valid geojson object

```
          "route_coords": {
            "type": "Feature",
            "properties": {},
            "geometry": {
              "type": "LineString",
              "coordinates": [
                [
                  -122.08337,
                  37.39025
                ],
                [
                  -122.08338,
                  37.39022
                ],
```

The new one does not

```
          "route_coords": [
            [
              37.39025,
              -122.08337
            ],
            [
              37.39022,
              -122.08338
            ],
            [
              37.39015,
              -122.08337
            ],
```

This breaks the code where we try to access the `geometry` child of `route_coords`

```
len(trip["route_coords"]["geometry"]["coordinates"])
```

Please fix the regression and attempt to fix the rest of the visualization (the
route part) similar to the fix for the start and end locations.

Bonus points if you can have a popup displaying the validity show up when the
user clicks on any map feature.