### PR TITLE
Initial fix for verifying rerouted entries

### DIFF
--- a/spec_creation/Verify_rerouted_entries.ipynb
+++ b/spec_creation/Verify_rerouted_entries.ipynb
@@ -1,0 +1,126 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import polyline as pl\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load all data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "original_route = json.load(open(\"final_sfbayarea_filled/train_bus_ebike_mtv_ucb.filled.json\"))\n",
+    "sm_reroute = json.load(open(\"final_sfbayarea_filled_reroutes/train_bus_ebike_mtv_ucb.filled.reroute.json\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "combined_spec = json.load(open(\"final_sfbayarea/train_bus_ebike_mtv_ucb.json\"))\n",
+    "combined_reroute = json.load(open(\"final_sfbayarea_filled_reroutes/train_bus_ebike_mtv_ucb.filled.reroute.json\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Check input spec\n",
+    "\n",
+    "First, we verify that we have a trajectory defined for each leg in the spec, and that the leg contains a polyline. This is true by spot-checking, but this checks it programmatically"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def check_polyline_existence(t_or_l):\n",
+    "    trajectory_key_list = t_or_l.keys() - [\"id\", \"name\", \"mode\", \"start_loc\", \"end_loc\", \"multiple_occupancy\"]\n",
+    "    if len(trajectory_key_list) != 1:\n",
+    "        print(\"key list = %s\" % trajectory_key_list)\n",
+    "        return False\n",
+    "    trajectory_key = next(iter(trajectory_key_list))\n",
+    "    polyline_exists = (trajectory_key == \"polyline\" or trajectory_key == \"polylines\")\n",
+    "    if not polyline_exists:\n",
+    "        if trajectory_key == 'waypoint_coords':\n",
+    "            wc = t_or_l[\"waypoint_coords\"]\n",
+    "            if type(wc) == list:\n",
+    "                polyline_exists_list = [\"polyline\" in w for w in wc]\n",
+    "                polyline_exists = pd.Series(polyline_exists_list).all()\n",
+    "            else:\n",
+    "                polyline_exists = \"polyline\" in wc\n",
+    "        else:\n",
+    "            polyline_exists = False\n",
+    "    else:\n",
+    "        pass\n",
+    "    print(\"Trajectory is defined using %s, includes polyline %s\" % (trajectory_key, polyline_exists))\n",
+    "    if not polyline_exists:\n",
+    "        print(\"======POLYLINE NOT FOUND for %s\" % t_or_l[\"id\"])\n",
+    "    return polyline_exists"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for t in combined_spec[\"evaluation_trips\"]:\n",
+    "    if \"legs\" not in t:\n",
+    "        print(\"Checking unimodal trip %s\" % t[\"id\"])\n",
+    "        check_polyline_existence(t)\n",
+    "        continue\n",
+    "    for l in t[\"legs\"]:\n",
+    "        print(\"Checking leg %s in trip %s\" % (l[\"id\"], t[\"id\"]))\n",
+    "        check_polyline_existence(l)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/spec_creation/final_sfbayarea/train_bus_ebike_mtv_ucb.json
+++ b/spec_creation/final_sfbayarea/train_bus_ebike_mtv_ucb.json
@@ -223,9 +223,9 @@
                       "type": "Feature",
                       "geometry": {
                         "type": "LineString",
-                        "coordinates": [],
-                        "polyline": "kpcfF`ogiVCUCw@SAYCe@Cy@CI?"
-                      }
+                        "coordinates": []
+                      },
+                      "polyline": "kpcfF`ogiVCUCw@SAYCe@Cy@CI?"
                     }
                 },{
                     "id": "city_bus_short",
@@ -335,18 +335,6 @@
                     "id": "walk to the bikeshare location",
                     "name": "HFA-B to bikeshare location",
                     "mode": "WALKING",
-                    "polylines": [
-                      {
-                        "polyline": "ikcfFtleiVA?c@LK@IAGEQOCACCE@m@FE@C@A??MFMVGRCTSBG?Ag@sDQcAWWO}BLSHGDEl@IBA~@KAYBMJIDWH?PC@???BCNAAO",
-                        "valid_start_fmt_date": "2019-07-16",
-                        "valid_end_fmt_date": "2019-08-30"
-                      },
-                      {
-                        "polyline": "ikcfFtleiVh@O`@MDANE??HCGeA?CAIAQMkBEi@Ca@MeB?KEk@G{@Ei@AUEg@Df@@TLABATAN?XE",
-                        "valid_start_fmt_date": "2019-09-01",
-                        "valid_end_fmt_date": "2020-04-30"
-                      }
-                    ],
                     "start_loc": {
                       "type": "Feature",
                       "properties": {
@@ -517,9 +505,9 @@
                           [ -122.27141618728638, 37.848997707091975 ],
                           [ -122.27179169654846, 37.84719742398725 ],
                           [ -122.27291822433472, 37.846312092173754 ]
-                        ],
-                        "polyline": "klcfFvydiVBEHHD@H?PC@?BCNA@TDh@Fz@Dj@?JLdBB`@Dh@LjB@P@H?BFdAFr@PfC@LPtC@P@LNpB@ZHbAJ`B@NDf@Dz@@N@R@VDj@FhA@@F`ALpBJ|A@PH`ARvC@RB\\Fz@@PDj@BX@NBP@RJtA@NJxABf@Dp@Dj@BZLATAzAKNARAPANAXAFApAGPANALANARAlBKRALANATAzAKRAPALALAXCF?nAITALAPANARA~AKRALAN?LAd@ClAIPANANALAPAb@CD?TAV@H@d@DN@N@RB`@DR?\\?JBFDFDZXNLTNLFFDdCn@PFLDnBh@n@PNDPF|Cz@NDLDb@JlA\\ZD`@?V?\\HND~@VPD^H^Ll@NPDpA^l@PRFp@PfAZXHx@TVHp@PRFF@VHf@LLDNJRVLRNJNBPBV?L?RBNBLDlAZ~@VHBNDNDJBfA\\LDTFXHHBPFNDr@LfCZh@FVBRABAHA@?A?DRFPLXLXPV\\ZFFpAhAd@`@DDrAnAjArA|@tAh@x@Tb@`@p@HNJV\\QJELCVI^IXGp@KlASJAdC]xB_@FARYfAP\\Jd@NdD~@|Bn@`AV~@VNDhBf@JB`AXt@RbAXf@NPDZHPFVHjCr@HBJBh@NhAZHBzBl@JDJBr@RbAXNDRFxA`@@?D@HBJBpBj@LDNDzCx@TFEV?JBZ"
-                      }
+                        ]
+                      },
+                      "polyline": "klcfFvydiVBEHHD@H?PC@?BCNA@TDh@Fz@Dj@?JLdBB`@Dh@LjB@P@H?BFdAFr@PfC@LPtC@P@LNpB@ZHbAJ`B@NDf@Dz@@N@R@VDj@FhA@@F`ALpBJ|A@PH`ARvC@RB\\Fz@@PDj@BX@NBP@RJtA@NJxABf@Dp@Dj@BZLATAzAKNARAPANAXAFApAGPANALANARAlBKRALANATAzAKRAPALALAXCF?nAITALAPANARA~AKRALAN?LAd@ClAIPANANALAPAb@CD?TAV@H@d@DN@N@RB`@DR?\\?JBFDFDZXNLTNLFFDdCn@PFLDnBh@n@PNDPF|Cz@NDLDb@JlA\\ZD`@?V?\\HND~@VPD^H^Ll@NPDpA^l@PRFp@PfAZXHx@TVHp@PRFF@VHf@LLDNJRVLRNJNBPBV?L?RBNBLDlAZ~@VHBNDNDJBfA\\LDTFXHHBPFNDr@LfCZh@FVBRABAHA@?A?DRFPLXLXPV\\ZFFpAhAd@`@DDrAnAjArA|@tAh@x@Tb@`@p@HNJV\\QJELCVI^IXGp@KlASJAdC]xB_@FARYfAP\\Jd@NdD~@|Bn@`AV~@VNDhBf@JB`AXt@RbAXf@NPDZHPFVHjCr@HBJBh@NhAZHBzBl@JDJBr@RbAXNDRFxA`@@?D@HBJBpBj@LDNDzCx@TFEV?JBZ"
                     },{
                       "type": "Feature",
                       "properties": {
@@ -532,9 +520,10 @@
                           [ -122.27141618728638, 37.848997707091975 ],
                           [ -122.27179169654846, 37.84719742398725 ],
                           [ -122.27291822433472, 37.846312092173754 ]
-                        ],
-                        "polyline": "gjcfFbydiV@N@TDh@Fz@Dj@?JLdBB`@Dh@LjB@P@H?BFdAFr@PfC@LPtC@P@LNpB@ZHbAJ`B@NDf@Dz@@N@R@VDj@FhA@@F`ALpBJ|A@PH`ARvC@RB\\Fz@@PDj@BX@NBP@RJtA@NJxABf@Dp@Dj@BZLATAzAKNARAPANAXAFApAGPANALANARAlBKRALANATAzAKRAPALALAXCF?nAITALAPANARA~AKRALAN?LAd@ClAIPANANALAPAb@CD?TAV@H@d@DN@N@RB`@DR?\\?JBFDFDZXNLTNLFFDdCn@PFLDnBh@n@PNDPF|Cz@NDLDb@JlA\\ZD`@?V?\\HND~@VPD^H^Ll@NPDpA^l@PRFp@PfAZXHx@TVHp@PRFF@VHf@LLDNJRVLRNJNBPBV?L?RBNBLDlAZ~@VHBNDNDJBfA\\LDTFXHHBPFNDr@LfCZh@FVBRABAHA@?A?DRFPLXLXPV\\ZFFpAhAd@`@DDrAnAjArA|@tAh@x@Tb@`@p@HNJV\\QJELCVI^IXGp@KlASJAdC]xB_@FARYfAP\\Jd@NdD~@|Bn@`AV~@VNDhBf@JB`AXt@RbAXf@NPDZHPFVHjCr@HBJBh@NhAZHBzBl@JDJBr@RbAXNDRFxA`@@?D@HBJBpBj@LDNDzCx@TFEV?JBZ"
-                    }}
+                        ]
+                      },
+                      "polyline": "gjcfFbydiV@N@TDh@Fz@Dj@?JLdBB`@Dh@LjB@P@H?BFdAFr@PfC@LPtC@P@LNpB@ZHbAJ`B@NDf@Dz@@N@R@VDj@FhA@@F`ALpBJ|A@PH`ARvC@RB\\Fz@@PDj@BX@NBP@RJtA@NJxABf@Dp@Dj@BZLATAzAKNARAPANAXAFApAGPANALANARAlBKRALANATAzAKRAPALALAXCF?nAITALAPANARA~AKRALAN?LAd@ClAIPANANALAPAb@CD?TAV@H@d@DN@N@RB`@DR?\\?JBFDFDZXNLTNLFFDdCn@PFLDnBh@n@PNDPF|Cz@NDLDb@JlA\\ZD`@?V?\\HND~@VPD^H^Ll@NPDpA^l@PRFp@PfAZXHx@TVHp@PRFF@VHf@LLDNJRVLRNJNBPBV?L?RBNBLDlAZ~@VHBNDNDJBfA\\LDTFXHHBPFNDr@LfCZh@FVBRABAHA@?A?DRFPLXLXPV\\ZFFpAhAd@`@DDrAnAjArA|@tAh@x@Tb@`@p@HNJV\\QJELCVI^IXGp@KlASJAdC]xB_@FARYfAP\\Jd@NdD~@|Bn@`AV~@VNDhBf@JB`AXt@RbAXf@NPDZHPFVHjCr@HBJBh@NhAZHBzBl@JDJBr@RbAXNDRFxA`@@?D@HBJBpBj@LDNDzCx@TFEV?JBZ"
+                    }
                     ]
                 },{ 
                     "id": "express_bus",


### PR DESCRIPTION
Findings:
- all the legs had polylines defined
- for the vast majority of these, the polylines were defined in the waypoint_coords
    But they were defined within the geometry, not outside (should they be in the geometry? outside?)

The new Verify_rerouted_entries notebook allows us to verify the structure of the legs programatically
https://github.com/MobilityNet/mobilitynet-analysis-scripts/pull/48#issuecomment-777160586

The auto-fill code was not handling this correctly, which is why we ran into
https://github.com/MobilityNet/mobilitynet-analysis-scripts/pull/48#issuecomment-775538734
and
https://github.com/MobilityNet/mobilitynet-analysis-scripts/pull/48#issuecomment-776439847

We need to decide how we are representing polylines and handle them properly before proceeding with validation.