### PR TITLE
Add code to compare the coordinates directly against the original specs

### DIFF
--- a/spec_creation/Verify_rerouted_entries.ipynb
+++ b/spec_creation/Verify_rerouted_entries.ipynb
@@ -107,16 +107,37 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "def check_coordinates(l1, l2):\n",
+    "    if l1 == l2:\n",
+    "        return True\n",
+    "    elif len(l1) != len(l2):\n",
+    "        print(\"=== list lengths don't match: %s != %s\" % (len(l1), len(l2)))\n",
+    "        return False\n",
+    "    else:\n",
+    "        for i, (e1, e2) in enumerate(zip(l1, l2)):\n",
+    "            if e1 != e2:\n",
+    "                print(\"=== mismatch found at index %i: %s != %s\" % (i, e1, e2))\n",
+    "                return False\n",
+    "        print(\"=== elements match, but lists don't match?!: %s != %s\" % (l1, l2))\n",
+    "        return False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def validate_shim_leg(ti, t, li, l):\n",
     "    if len(l[\"loc\"]) == 1:\n",
     "        orig_loc = original_route[\"evaluation_trips\"][ti][\"legs\"][li][\"loc\"]\n",
     "        combo_loc = l[\"loc\"][0]\n",
     "        # print(orig_loc[\"geometry\"][\"coordinates\"], combo_loc[\"geometry\"][\"coordinates\"])\n",
-    "        valid = orig_loc[\"geometry\"][\"coordinates\"] == combo_loc[\"geometry\"][\"coordinates\"]\n",
+    "        valid = check_coordinates(orig_loc[\"geometry\"][\"coordinates\"], combo_loc[\"geometry\"][\"coordinates\"])\n",
     "        if not valid:\n",
-    "            print(\"!!! Leg %s has not been rerouted, check against original route = %s!!!\" % (l[\"id\"], valid))\n",
+    "            print(\"!!! Shim Leg %s has not been rerouted, check against original route = %s!!!\" % (l[\"id\"], valid))\n",
     "        else:\n",
-    "            print(\"Leg %s has not been rerouted, check against original route = %s\" % (l[\"id\"], valid))\n",
+    "            print(\"Shim Leg %s has not been rerouted, check against original route = %s\" % (l[\"id\"], valid))\n",
     "    else:\n",
     "        print(\"=== Leg %s has %s reroutes, need to check each of them\")"
    ]
@@ -128,11 +149,12 @@
    "outputs": [],
    "source": [
     "def validate_leg_key(ti, t, li, l, key):\n",
-    "    l = combined_reroute[\"evaluation_trips\"][ti][\"legs\"][li]\n",
-    "    orig_l = combined_reroute[\"evaluation_trips\"][ti][\"legs\"][li]\n",
+    "    orig_l = original_route[\"evaluation_trips\"][ti][\"legs\"][li]\n",
     "    reroute_l = sm_reroute[\"evaluation_trips\"][ti][\"legs\"][li]\n",
-    "    if len(l[key]) == 0:\n",
-    "        return False\n",
+    "    if len(l[key]) == 1:\n",
+    "        # print(l[key][0][\"geometry\"][\"coordinates\"])\n",
+    "        # print(orig_l[key][\"geometry\"][\"coordinates\"])\n",
+    "        return check_coordinates(l[key][0][\"geometry\"][\"coordinates\"], orig_l[key][\"geometry\"][\"coordinates\"])\n",
     "    if len(l[key]) > 1:\n",
     "        return True"
    ]
@@ -144,18 +166,18 @@
    "outputs": [],
    "source": [
     "def validate_travel_leg(ti, t, li, l):\n",
-    "    rerouted_feature_list = []\n",
-    "    if len(l[\"start_loc\"]) > 1:\n",
-    "        rerouted_feature_list.append(\"start_loc\")\n",
-    "    if len(l[\"end_loc\"]) > 1:\n",
-    "        rerouted_feature_list.append(\"end_loc\")\n",
-    "    if len(l[\"route_coords\"]) > 1:\n",
-    "        rerouted_feature_list.append(\"route_coords\")\n",
+    "    invalid_feature_list = []\n",
+    "    if not validate_leg_key(ti, t, li, l, \"start_loc\"):\n",
+    "        invalid_feature_list.append(\"start_loc\")\n",
+    "    if not validate_leg_key(ti, t, li, l, \"end_loc\"):\n",
+    "        invalid_feature_list.append(\"end_loc\")\n",
+    "    if not validate_leg_key(ti, t, li, l, \"route_coords\"):\n",
+    "        invalid_feature_list.append(\"route_coords\")\n",
     "    \n",
-    "    if len(rerouted_feature_list) > 0:\n",
-    "        print(\"!!Leg %s in trip %s has %s reroutes!!\" % (l[\"id\"], t[\"id\"], rerouted_feature_list))\n",
+    "    if len(invalid_feature_list) > 0:\n",
+    "        print(\"!! Travel Leg %s in trip %s has invalid keys %s !!\" % (l[\"id\"], t[\"id\"], invalid_feature_list))\n",
     "    else: \n",
-    "        print(\"Leg %s in trip %s has no reroutes\" % (l[\"id\"], t[\"id\"]))"
+    "        print(\"Travel Leg %s in trip %s has no reroutes\" % (l[\"id\"], t[\"id\"]))"
    ]
   },
   {
@@ -171,6 +193,13 @@
     "        else:\n",
     "            validate_travel_leg(ti, t, li, l)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",

--- a/spec_creation/Verify_rerouted_entries.ipynb
+++ b/spec_creation/Verify_rerouted_entries.ipynb
@@ -93,6 +93,91 @@
     "        print(\"Checking leg %s in trip %s\" % (l[\"id\"], t[\"id\"]))\n",
     "        check_polyline_existence(l)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Check output spec\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def validate_shim_leg(ti, t, li, l):\n",
+    "    if len(l[\"loc\"]) == 1:\n",
+    "        orig_loc = original_route[\"evaluation_trips\"][ti][\"legs\"][li][\"loc\"]\n",
+    "        combo_loc = l[\"loc\"][0]\n",
+    "        # print(orig_loc[\"geometry\"][\"coordinates\"], combo_loc[\"geometry\"][\"coordinates\"])\n",
+    "        valid = orig_loc[\"geometry\"][\"coordinates\"] == combo_loc[\"geometry\"][\"coordinates\"]\n",
+    "        if not valid:\n",
+    "            print(\"!!! Leg %s has not been rerouted, check against original route = %s!!!\" % (l[\"id\"], valid))\n",
+    "        else:\n",
+    "            print(\"Leg %s has not been rerouted, check against original route = %s\" % (l[\"id\"], valid))\n",
+    "    else:\n",
+    "        print(\"=== Leg %s has %s reroutes, need to check each of them\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def validate_leg_key(ti, t, li, l, key):\n",
+    "    l = combined_reroute[\"evaluation_trips\"][ti][\"legs\"][li]\n",
+    "    orig_l = combined_reroute[\"evaluation_trips\"][ti][\"legs\"][li]\n",
+    "    reroute_l = sm_reroute[\"evaluation_trips\"][ti][\"legs\"][li]\n",
+    "    if len(l[key]) == 0:\n",
+    "        return False\n",
+    "    if len(l[key]) > 1:\n",
+    "        return True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def validate_travel_leg(ti, t, li, l):\n",
+    "    rerouted_feature_list = []\n",
+    "    if len(l[\"start_loc\"]) > 1:\n",
+    "        rerouted_feature_list.append(\"start_loc\")\n",
+    "    if len(l[\"end_loc\"]) > 1:\n",
+    "        rerouted_feature_list.append(\"end_loc\")\n",
+    "    if len(l[\"route_coords\"]) > 1:\n",
+    "        rerouted_feature_list.append(\"route_coords\")\n",
+    "    \n",
+    "    if len(rerouted_feature_list) > 0:\n",
+    "        print(\"!!Leg %s in trip %s has %s reroutes!!\" % (l[\"id\"], t[\"id\"], rerouted_feature_list))\n",
+    "    else: \n",
+    "        print(\"Leg %s in trip %s has no reroutes\" % (l[\"id\"], t[\"id\"]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for ti, t in enumerate(combined_reroute[\"evaluation_trips\"]):\n",
+    "    for li, l in enumerate(t[\"legs\"]):\n",
+    "        if \"loc\" in l:\n",
+    "            validate_shim_leg(ti, t, li, l)\n",
+    "        else:\n",
+    "            validate_travel_leg(ti, t, li, l)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Unfortunately, all the travel leg checks currently fail.
It looks like the formatting of the coordinates is not correct; there is an additional array wrapper for the coordinates.
That would make it invalid geojson.