### PR TITLE
Add in the check for the rerouted entries as well

### DIFF
--- a/spec_creation/Verify_rerouted_entries.ipynb
+++ b/spec_creation/Verify_rerouted_entries.ipynb
@@ -25,7 +25,7 @@
    "outputs": [],
    "source": [
     "original_route = json.load(open(\"final_sfbayarea_filled/train_bus_ebike_mtv_ucb.filled.json\"))\n",
-    "sm_reroute = json.load(open(\"final_sfbayarea_filled_reroutes/train_bus_ebike_mtv_ucb.filled.reroute.json\"))"
+    "sm_reroute = json.load(open(\"final_sfbayarea_filled/train_bus_ebike_sm_reroute_mtv_ucb.filled.json\"))"
    ]
   },
   {
@@ -154,9 +154,19 @@
     "    if len(l[key]) == 1:\n",
     "        # print(l[key][0][\"geometry\"][\"coordinates\"])\n",
     "        # print(orig_l[key][\"geometry\"][\"coordinates\"])\n",
-    "        return check_coordinates(l[key][0][\"geometry\"][\"coordinates\"], orig_l[key][\"geometry\"][\"coordinates\"])\n",
+    "        # No reroute. The combo fields should be equal to both original and rerouted fields, and they should be equal to each other\n",
+    "        combo_orig = check_coordinates(l[key][0][\"geometry\"][\"coordinates\"], orig_l[key][\"geometry\"][\"coordinates\"])\n",
+    "        combo_reroute = check_coordinates(l[key][0][\"geometry\"][\"coordinates\"], reroute_l[key][\"geometry\"][\"coordinates\"])\n",
+    "        orig_reroute = check_coordinates(orig_l[key][\"geometry\"][\"coordinates\"], reroute_l[key][\"geometry\"][\"coordinates\"])\n",
+    "        print(combo_orig, combo_reroute, orig_reroute)\n",
+    "        return combo_orig and combo_reroute and orig_reroute\n",
     "    if len(l[key]) > 1:\n",
-    "        return True"
+    "        # Reroute. Only two reroutes supported. The first combo fields should be equal to original and the second should be the rerouted\n",
+    "        assert len(l[key]) == 2, \"Only two reroutes at this time, so use a simple check\"\n",
+    "        combo_orig = check_coordinates(l[key][0][\"geometry\"][\"coordinates\"], orig_l[key][\"geometry\"][\"coordinates\"])\n",
+    "        combo_reroute = check_coordinates(l[key][1][\"geometry\"][\"coordinates\"], reroute_l[key][\"geometry\"][\"coordinates\"])\n",
+    "        print(combo_orig, combo_reroute)\n",
+    "        return combo_orig and combo_reroute"
    ]
   },
   {
@@ -177,7 +187,7 @@
     "    if len(invalid_feature_list) > 0:\n",
     "        print(\"!! Travel Leg %s in trip %s has invalid keys %s !!\" % (l[\"id\"], t[\"id\"], invalid_feature_list))\n",
     "    else: \n",
-    "        print(\"Travel Leg %s in trip %s has no reroutes\" % (l[\"id\"], t[\"id\"]))"
+    "        print(\"Travel Leg %s in trip %s matches previous trajectories\" % (l[\"id\"], t[\"id\"]))"
    ]
   },
   {


### PR DESCRIPTION
In case of reroute, the first polyline should match the original entry and the
second polyline should match the new entry. With this, we have more failures :)

```
True True True
True True True
True True True
Travel Leg walk_to_caltrain in trip mtv_to_berkeley_sf_bart matches previous trajectories
Shim Leg wait_for_commuter_rail_aboveground has not been rerouted, check against original route = True

True True True
True True True
=== list lengths don't match: 427 != 426
=== list lengths don't match: 427 != 426
False False True
!! Travel Leg commuter_rail_aboveground in trip mtv_to_berkeley_sf_bart has invalid keys ['route_coords'] !!

Shim Leg tt_commuter_rail_aboveground_subway_underground has not been rerouted, check against original route = True
Shim Leg wait_for_subway_underground has not been rerouted, check against original route = True

True True True
True True True
=== list lengths don't match: 627 != 626
=== list lengths don't match: 627 != 626
False False True
!! Travel Leg subway_underground in trip mtv_to_berkeley_sf_bart has invalid keys ['route_coords'] !!

True True True
True True True
True True True
Travel Leg walk_to_bus in trip mtv_to_berkeley_sf_bart matches previous trajectories

Shim Leg wait_for_city_bus_short has not been rerouted, check against original route = True
True True True
True True True
True True True
Travel Leg city_bus_short in trip mtv_to_berkeley_sf_bart matches previous trajectories

Shim Leg walk_end has not been rerouted, check against original route = True
True True True
True True True
True True True
Travel Leg walk_urban_university in trip walk_urban_university matches previous trajectories

True True True
True True
=== list lengths don't match: 42 != 28
=== list lengths don't match: 28 != 42
False False
!! Travel Leg walk to the bikeshare location in trip berkeley_to_mtv_SF_express_bus has invalid keys ['route_coords'] !!

True True
True True True
True True
Travel Leg ebike_bikeshare_urban_long in trip berkeley_to_mtv_SF_express_bus matches previous trajectories

Shim Leg tt_ebike_bikeshare_urban_long_express_bus has not been rerouted, check against original route = True
Shim Leg wait_for_express_bus has not been rerouted, check against original route = True
True True True
True True
=== mismatch found at index 0: [-122.27932, 37.8312] != [-122.279322, 37.8311976]
True False
!! Travel Leg express_bus in trip berkeley_to_mtv_SF_express_bus has invalid keys ['route_coords'] !!

True True
True True True
True True
Travel Leg walk_downtown_urban_canyon in trip berkeley_to_mtv_SF_express_bus matches previous trajectories
Shim Leg wait_for_light_rail_below_above_ground has not been rerouted, check against original route = True
True True True
True True True
=== mismatch found at index 0: [-122.39623, 37.79329] != [-122.3962275, 37.7932925]
=== mismatch found at index 0: [-122.39623, 37.79329] != [-122.3962275, 37.7932925]
False False True
!! Travel Leg light_rail_below_above_ground in trip berkeley_to_mtv_SF_express_bus has invalid keys ['route_coords'] !!

Shim Leg tt_light_rail_below_above_ground_commuter_rail_with_tunnels has not been rerouted, check against original route = True
Shim Leg wait_for_commuter_rail_with_tunnels has not been rerouted, check against original route = True
True True True
True True True
True True True
Travel Leg commuter_rail_with_tunnels in trip berkeley_to_mtv_SF_express_bus matches previous trajectories
True True True
True True True
True True True
Travel Leg inner_suburb_downtown_walk in trip berkeley_to_mtv_SF_express_bus matches previous trajectories
```